### PR TITLE
add: private api wrapper (partial)

### DIFF
--- a/lib/private.py
+++ b/lib/private.py
@@ -1,0 +1,104 @@
+from .crypt import Crypt
+import hashlib
+import hmac
+import json
+import requests
+from requests import Response
+import time
+
+
+def get_keys() -> tuple:
+    crypo = Crypt()
+    return crypo.load()
+
+
+class PrivateApi:
+    def __init__(self):
+        self.url = 'https://api.bitflyer.jp'
+        self.api_key, self.secret_key = get_keys()
+
+    def base_get(self, path: str = None, **kwargs) -> dict:
+        timestamp: str = str(int(time.time()))
+        uri: str = self.url + path
+        method: str = "GET"
+        text: str = timestamp + method + path
+        sign: str = hmac.new(self.secret_key.encode("utf-8"), text.encode("utf-8"), hashlib.sha256).hexdigest()
+        headers: dict = {
+            'ACCESS-KEY': self.api_key,
+            'ACCESS-TIMESTAMP': timestamp,
+            'ACCESS-SIGN': sign
+        }
+        res: Response = requests.get(uri, headers=headers)
+        if res.text:
+            # TODO: namedtupleかdataclassにしたほうが良いかも？
+            result = {"status_code": res.status_code, "response": json.loads(res.text)}
+        else:
+            # TODO: namedtupleかdataclassにしたほうが良いかも？
+            result = {"status_code": res.status_code}
+        return result
+
+    def base_post(self, path: str = None, **kwargs) -> dict:
+        timestamp: str = str(int(time.time()))
+        body: str = str(kwargs)
+        method: str = "POST"
+        uri: str = self.url + path
+        text: str = timestamp + method + path + body
+        sign: str = hmac.new(self.secret_key.encode("utf-8"), text.encode("utf-8"), hashlib.sha256).hexdigest()
+        headers: dict = {
+            'ACCESS-KEY': self.api_key,
+            'ACCESS-TIMESTAMP': timestamp,
+            'ACCESS-SIGN': sign,
+            'Content-Type': 'application/json'
+        }
+        res: Response = requests.post(uri, headers=headers, data=body)
+        if res.text:
+            # TODO: namedtupleかdataclassにしたほうが良いかも？
+            result = {"status_code": res.status_code, "response": json.loads(res.text)}
+        else:
+            # TODO: namedtupleかdataclassにしたほうが良いかも？
+            result = {"status_code": res.status_code}
+        return result
+
+    def get_permissions(self):
+        """
+        API キーの権限を取得
+        :return: {status_code: int, response: list[str]}
+        """
+        path: str = "/v1/me/getpermissions"
+        return self.base_get(path=path)
+
+    def get_balance(self):
+        """
+        資産残高を取得
+        :return: {status_code: int, response: list[dict]}
+        """
+        path: str = "/v1/me/getbalance"
+        return self.base_get(path=path)
+
+    def get_collateral(self):
+        """
+        証拠金の状態を取得
+        collateral: 預け入れた証拠金の評価額(円)
+        open_position_pnl: 建玉の評価損益(円)
+        require_collateral: 現在の必要証拠金(円)
+        keep_rate: 現在の証拠金維持率
+        :return: {status_code: int, response: dict}
+        """
+        path: str = "/v1/me/getcollateral"
+        return self.base_get(path=path)
+
+    def get_collateral_accounts(self):
+        """
+        通過別の証拠金の数量を取得
+        :return: {status_code: int, response: list[dict]}
+        """
+        path: str = "/v1/me/getcollateralaccounts"
+        return self.base_get(path=path)
+
+    def get_addresses(self) ->dict:
+        """
+        仮想通貨をbirFlyerアカウントに預入るためのアドレスを取得
+        :return: {status_code: int, response: list[dict]}
+        """
+        path: str = "/v1/me/getcollateralaccounts"
+        return self.base_get(path=path)

--- a/test/test_private.py
+++ b/test/test_private.py
@@ -1,0 +1,9 @@
+from lib.private import PrivateApi
+
+
+def test_get_permission():
+    private_api = PrivateApi()
+
+    hoge = private_api.get_permissions()
+    assert hoge["status_code"] == 200
+    print(hoge["response"])


### PR DESCRIPTION
# Purpose
[HAY-84](https://linear.app/hands/issue/HAY-84/private-apiのwrapper)の対応
birFlyer [private api](https://lightning.bitflyer.com/docs#http-private-api)を先行実装した。

# Implementation details
- クラス化
- getリクエスト用、postリクエスト用の関数を用意
- リクエスト実施時にsha256で暗号化する処理
- レスポンスを扱い安いように辞書化した。
- 一部エンドポイントを実装した。

# TODO
レスポンスはnamedtupleか、dataclassに詰めたほうが扱いやすいかもしれない。(やる場合は別途チケット化する)

# 動確
test_private.pyを実施した。

## 結果
```
============================= test session starts ==============================
collecting ... collected 1 item

test_private.py::test_get_permission 

============================== 1 passed in 0.33s ===============================

プロセスは終了コード 0 で終了しました
PASSED                              [100%]['/v1/getmarkets', '/v1/markets', '/v1/getmarkets/usa', '/v1/markets/usa', '/v1/getmarkets/eu', '/v1/markets/eu', '/v1/getboard', '/v1/board', '/v1/getticker', '/v1/ticker', '/v1/getexecutions', '/v1/executions', '/v1/getchats', '/v1/getchats/usa', '/v1/getchats/eu', '/v1/gethealth', '/v1/getboardstate', '/v1/getcorporateleverage', '/v1/me/getpermissions', '/v1/me/getbalance', '/v1/me/getcollateral', '/v1/me/getcollateralaccounts', '/v1/me/sendchildorder', '/v1/me/sendparentorder', '/v1/me/cancelchildorder', '/v1/me/cancelparentorder', '/v1/me/cancelallchildorders', '/v1/me/getchildorders', '/v1/me/getparentorders', '/v1/me/getparentorder', '/v1/me/getexecutions', '/v1/me/getpositions', '/v1/me/getcollateralhistory', '/v1/me/gettradingcommission', '/v1/me/getaddresses', '/v1/me/getcoinins', '/v1/me/getcoinouts', '/v1/me/getdeposits', '/v1/me/getwithdrawals', '/v1/me/getbankaccounts', '/v1/me/withdraw']
```
